### PR TITLE
fix request id issue

### DIFF
--- a/models/request.go
+++ b/models/request.go
@@ -26,7 +26,7 @@ func (r *RequestBody) Validate() error {
 		return errors.New("Bad request, bad format field 'method'")
 	}
 
-	if r.Id == nil || *r.Id == 0 {
+	if r.Id == nil {
 		return errors.New("Bad request, bad format field 'id'")
 	}
 

--- a/models/request.go
+++ b/models/request.go
@@ -11,7 +11,7 @@ import (
 type RequestBody struct {
 	JsonRpc string           `json:"jsonrpc"`
 	Method  string           `json:"method"`
-	Id      *uint            `json:"id"`
+	Id      *interface{}     `json:"id"`
 	Params  *json.RawMessage `json:"params,omitempty"`
 }
 

--- a/models/response.go
+++ b/models/response.go
@@ -9,10 +9,10 @@ type ResponseBody struct {
 	JsonRpc string           `json:"jsonrpc"`
 	Result  *json.RawMessage `json:"result,omitempty"`
 	Error   *Error           `json:"error,omitempty"`
-	Id      *uint            `json:"id"`
+	Id      *interface{}     `json:"id"`
 }
 
-func NewResponseError(error *Error, id *uint) *ResponseBody {
+func NewResponseError(error *Error, id *interface{}) *ResponseBody {
 	return &ResponseBody{
 		JsonRpc: "2.0",
 		Error:   error,
@@ -20,7 +20,7 @@ func NewResponseError(error *Error, id *uint) *ResponseBody {
 	}
 }
 
-func NewResponseBody(result *json.RawMessage, id *uint) *ResponseBody {
+func NewResponseBody(result *json.RawMessage, id *interface{}) *ResponseBody {
 	return &ResponseBody{
 		JsonRpc: "2.0",
 		Result:  result,


### PR DESCRIPTION
Считаю, что это условие лишнее. 
[В спецификации JSON-RPC](http://www.jsonrpc.org/historical/json-rpc-over-http.html) в секции 3.4 в примерах используется `id:0`.
В спецификации [JSON-RPC 2.0](http://www.jsonrpc.org/specification#request_object) нет ни слова про запрет 0.
Люди явно [пользуют](https://github.com/hyperledger/burrow/issues/464).
Ну и я не зря полез, тоже нарвался на либу, которая просто инкрементит `id` начиная с нуля